### PR TITLE
win: fix building on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
+    "cross-env": "^3.1.4",
     "eslint": "^3.3.0",
     "eslint-config-idiomatic": "^2.1.0",
     "eslint-loader": "^1.5.0",
@@ -39,7 +40,7 @@
     "webpack-node-externals": "^1.3.3"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack",
+    "build": "cross-env NODE_ENV=production webpack",
     "dev": "webpack --watch",
     "prepublish": "npm run build"
   }


### PR DESCRIPTION
Windows needs `cross-env` in order to compile as NODE_ENV will return an error saying that it's not a valid command. 