### PR TITLE
Background fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,12 +61,13 @@ export function decorateHyper(Hyper, { React, notify }) {
     }
 
     render() {
+      const { fontFamily, hyperline } = this.props;
       return <Hyper {...this.props} customChildren={(
         <HyperLine
-          fontFamily={this.props.fontFamily}
+          fontFamily={fontFamily}
           colors={this.colors}
           plugins={this.plugins}
-          background={this.props.hyperline.background}
+          background={hyperline && hyperline.background}
         />
       )} />
     }

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,8 @@ export function decorateHyper(Hyper, { React, notify }) {
         ]),
         fontFamily: PropTypes.string,
         style: PropTypes.object,
-        hyperline: PropTypes.object
+        hyperline: PropTypes.object,
+        backgroundColor: PropTypes.object,
       }
     }
 
@@ -61,15 +62,20 @@ export function decorateHyper(Hyper, { React, notify }) {
     }
 
     render() {
-      const { fontFamily, hyperline } = this.props;
-      return <Hyper {...this.props} customChildren={(
-        <HyperLine
-          fontFamily={fontFamily}
-          colors={this.colors}
-          plugins={this.plugins}
-          background={hyperline && hyperline.background}
+      return (
+        <Hyper
+          {...this.props}
+          customChildren={(
+            <HyperLine
+              fontFamily={this.props.fontFamily}
+              colors={this.colors}
+              plugins={this.plugins}
+              background={this.props.hyperline && this.props.hyperline.background}
+              hyperBackground={this.props.backgroundColor}
+            />
+          )}
         />
-      )} />
+      );
     }
   }
 }

--- a/src/lib/core/hyperline.js
+++ b/src/lib/core/hyperline.js
@@ -1,7 +1,7 @@
 import Color from 'color'
 
 export const hyperlineFactory = (React) => {
-  const HyperLine = ({ fontFamily, colors, plugins, background}) => {
+  const HyperLine = ({ fontFamily, colors, plugins, background, hyperBackground}) => {
     const lineStyle = {
       display: 'flex',
       alignItems: 'center',
@@ -13,7 +13,7 @@ export const hyperlineFactory = (React) => {
       font: 'bold 12px Monospace',
       pointerEvents: 'none',
       fontFamily,
-      background: background || Color(colors.black).darken(0.1).hslString()
+      background: background || Color(hyperBackground || colors.black).alpha(0.2).rgbaString(),
     }
 
     return (
@@ -30,7 +30,8 @@ export const hyperlineFactory = (React) => {
     fontFamily: React.PropTypes.string.isRequired,
     colors: React.PropTypes.object.isRequired,
     plugins: React.PropTypes.array.isRequired,
-    background: React.PropTypes.string
+    background: React.PropTypes.string,
+    hyperBackground: React.PropTypes.string,
   }
 
   return HyperLine


### PR DESCRIPTION
This will allow the background to fallback to the same backgroundColor already defined by hyper to style this plugin correctly always. If background is specified in the hyperline config object we will use that instead.

Once we merge this it would be nice to do an `npm publish` as well.

For the time being if anyone wants to use this library with the latest changes, feel free to use `hyperline-magus`.

![default-background](https://cloud.githubusercontent.com/assets/290084/23851089/69475c2c-079f-11e7-8989-9304a97cca4d.gif)


