### PR TITLE
Add moment.js based time plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "color": "^0.11.3",
     "json-loader": "^0.5.4",
+    "moment": "^2.18.1",
     "public-ip": "^2.0.1",
     "systeminformation": "^3.4.1"
   }

--- a/src/lib/plugins/index.js
+++ b/src/lib/plugins/index.js
@@ -5,9 +5,10 @@ import * as uptime from './uptime'
 import * as cpu from './cpu'
 import * as network from './network'
 import * as battery from './battery'
+import * as time from './time';
 
 /**
  * Exports a mapping from plugin name to associated component factory.
  * Object keys match those used in the configuration object
  */
-export default { hostname, ip, memory, uptime, cpu, network, battery }
+export default { hostname, ip, memory, uptime, cpu, network, battery, time }

--- a/src/lib/plugins/time.js
+++ b/src/lib/plugins/time.js
@@ -1,0 +1,82 @@
+import pluginWrapperFactory from '../core/PluginWrapper'
+import {iconStyles} from '../utils/icons'
+import { colorExists } from '../utils/colors'
+import moment from 'moment'
+
+const pluginIcon = (React, fillColor) => (
+  <svg style={iconStyles} xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fillRule="evenodd">
+      <g fill={fillColor} transform="translate(1.000000, 1.000000)">
+        <g>
+          <path d="M0,0 L14,0 L14,14 L0,14 L0,0 Z M1,1 L13,1 L13,13 L1,13 L1,1 Z"></path>
+          <path d="M6,2 L7,2 L7,7 L6,7 L6,2 Z M6,7 L10,7 L10,8 L6,8 L6,7 Z"></path>
+        </g>
+      </g>
+    </g>
+  </svg>
+)
+
+export function componentFactory(React, colors) {
+  const {Component, PropTypes} = React
+  return class extends Component {
+    static displayName() {
+      return 'Time plugin'
+    }
+
+    static propTypes() {
+      return {
+        options: PropTypes.object
+      }
+    }
+
+    constructor(props) {
+      super(props)
+      this.state = {
+        time: this.getCurrentTime()
+      }
+    }
+
+    componentDidMount() {
+      this.interval = setInterval(() => {
+        this.setState({ time: this.getCurrentTime() })
+      }, 100)
+    }
+
+    componentWillUnmount() {
+      clearInterval(this.interval);
+    }
+
+    getCurrentTime() {
+      return moment().format(this.props.options.formatString)
+    }
+
+    render() {
+      const PluginWrapper = pluginWrapperFactory(React)
+      const fillColor = colors[this.props.options.color]
+
+      return (
+        <PluginWrapper color={fillColor}>
+          {pluginIcon(React, fillColor)} {this.state.time}
+        </PluginWrapper>
+      )
+    }
+  }
+}
+
+export const validateOptions = (options) => {
+  const errors = []
+
+  if (!options.color) {
+    errors.push('\'color\' color string is required but missing.')
+  } else if (!colorExists(options.color)) {
+    errors.push(`invalid color '${options.color}'`)
+  }
+
+  return errors
+}
+
+export const defaultOptions = {
+  color: 'lightBlue',
+  // https://momentjs.com/ format
+  formatString: 'LTS'
+}


### PR DESCRIPTION
Adds a time plugin. Very useful for when terminal is in fullscreen mode or top bar is hidden.

Utilizes moment.js so users can override their outputted format with their settings.

![screen shot 2017-03-25 at 11 31 59 am](https://cloud.githubusercontent.com/assets/1316246/24325047/b13536a4-114e-11e7-8db7-449740ea1929.png)
