### PR TITLE
Show uptime in a more human-friendly format (days and hours)

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,5 @@
+{
+  "testRegex": "(/__tests__/.*|\\.(test|spec))\\.js$",
+  "moduleFileExtensions": [ "js" ],
+  "moduleDirectories": [ "node_modules" ]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.11.4",
+    "babel-jest": "^19.0.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
@@ -23,6 +24,7 @@
     "eslint-config-idiomatic": "^2.1.0",
     "eslint-loader": "^1.5.0",
     "eslint-plugin-react": "^6.1.1",
+    "jest": "^19.0.2",
     "webpack": "^1.13.1",
     "webpack-node-externals": "^1.3.3"
   },
@@ -33,6 +35,8 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack",
+    "tdd": "jest --watch -c jest.config.json",
+    "test": "jest -c jest.config.json",
     "dev": "webpack --watch"
   },
   "dependencies": {

--- a/src/lib/plugins/uptime.js
+++ b/src/lib/plugins/uptime.js
@@ -1,4 +1,5 @@
 import os from 'os'
+import moment from 'moment'
 import { iconStyles } from '../utils/icons'
 import pluginWrapperFactory from '../core/PluginWrapper'
 import { colorExists } from '../utils/colors'
@@ -48,7 +49,14 @@ export function componentFactory(React, colors) {
     }
 
     getUptime() {
-      return (os.uptime()/3600).toFixed(0)
+      const uptime = moment.duration(os.uptime(), 'seconds')
+      const days = uptime.days()
+      const hours = uptime.hours()
+      const daysFormatted = days ? days + 'd' : ''
+      const hoursFormatted = hours ? hours + 'h' : ''
+      const divider = (days && hours) ? ' ' : ''
+
+      return daysFormatted + divider + hoursFormatted
     }
 
     render() {
@@ -57,7 +65,7 @@ export function componentFactory(React, colors) {
 
       return (
         <PluginWrapper color={fillColor}>
-          {pluginIcon(React, fillColor)} {this.state.uptime}HRS
+          {pluginIcon(React, fillColor)} {this.state.uptime}
         </PluginWrapper>
       )
     }

--- a/src/lib/plugins/uptime.js
+++ b/src/lib/plugins/uptime.js
@@ -1,5 +1,5 @@
 import os from 'os'
-import moment from 'moment'
+import { formatUptime } from '../utils/time'
 import { iconStyles } from '../utils/icons'
 import pluginWrapperFactory from '../core/PluginWrapper'
 import { colorExists } from '../utils/colors'
@@ -49,14 +49,7 @@ export function componentFactory(React, colors) {
     }
 
     getUptime() {
-      const uptime = moment.duration(os.uptime(), 'seconds')
-      const days = uptime.days()
-      const hours = uptime.hours()
-      const daysFormatted = days ? days + 'd' : ''
-      const hoursFormatted = hours ? hours + 'h' : ''
-      const divider = (days && hours) ? ' ' : ''
-
-      return daysFormatted + divider + hoursFormatted
+      return formatUptime(os.uptime())
     }
 
     render() {

--- a/src/lib/utils/__tests__/__snapshots__/time.js.snap
+++ b/src/lib/utils/__tests__/__snapshots__/time.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`time formatUptime 1 day 4 hours 1`] = `"1d 4h"`;
+
+exports[`time formatUptime 3 days 1`] = `"3d"`;
+
+exports[`time formatUptime 3 days 8 minutes 1`] = `"3d"`;
+
+exports[`time formatUptime 3 hours 48 minutes 1`] = `"4h"`;
+
+exports[`time formatUptime 3 seconds 1`] = `"0h"`;
+
+exports[`time formatUptime 4 hours 1`] = `"4h"`;
+
+exports[`time formatUptime 23 hours 1`] = `"23h"`;
+
+exports[`time formatUptime 23 hours 17 minutes 1`] = `"23h"`;
+
+exports[`time formatUptime 23 hours 49 minutes 1`] = `"1d"`;
+
+exports[`time formatUptime 23 minutes 1`] = `"0h"`;
+
+exports[`time formatUptime 29 minutes 1`] = `"0h"`;
+
+exports[`time formatUptime 30 minutes 1`] = `"1h"`;
+
+exports[`time formatUptime 31 minutes 1`] = `"1h"`;
+
+exports[`time formatUptime is a function 1`] = `[Function]`;

--- a/src/lib/utils/__tests__/time.js
+++ b/src/lib/utils/__tests__/time.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import { formatUptime } from '../time'
+
+describe('time', () => {
+  describe('formatUptime', () => {
+    it('is a function', () => expect(formatUptime).toMatchSnapshot())
+    it('3 seconds', () => expect(formatUptime(3)).toMatchSnapshot())
+    it('23 minutes', () => expect(formatUptime(1380)).toMatchSnapshot())
+    it('29 minutes', () => expect(formatUptime(1740)).toMatchSnapshot())
+    it('30 minutes', () => expect(formatUptime(1800)).toMatchSnapshot())
+    it('31 minutes', () => expect(formatUptime(1860)).toMatchSnapshot())
+    it('3 hours 48 minutes', () => expect(formatUptime(13680)).toMatchSnapshot())
+    it('4 hours', () => expect(formatUptime(14400)).toMatchSnapshot())
+    it('23 hours', () => expect(formatUptime(82800)).toMatchSnapshot())
+    it('23 hours 17 minutes', () => expect(formatUptime(83820)).toMatchSnapshot())
+    it('23 hours 49 minutes', () => expect(formatUptime(85740)).toMatchSnapshot())
+    it('1 day 4 hours', () => expect(formatUptime(100800)).toMatchSnapshot())
+    it('3 days', () => expect(formatUptime(259200)).toMatchSnapshot())
+    it('3 days 8 minutes', () => expect(formatUptime(259680)).toMatchSnapshot())
+  })
+})

--- a/src/lib/utils/time.js
+++ b/src/lib/utils/time.js
@@ -1,7 +1,13 @@
 import moment from 'moment'
 
 export function formatUptime(uptime) {
-  const uptimeInMoment = moment.duration(uptime, 'seconds')
+  const uptimeInHours = Number((uptime/3600).toFixed(0));
+
+  if (uptimeInHours === 0) {
+    return '0h'
+  }
+
+  const uptimeInMoment = moment.duration(uptimeInHours, 'hours')
   const days = uptimeInMoment.days()
   const hours = uptimeInMoment.hours()
   const daysFormatted = days ? days + 'd' : ''

--- a/src/lib/utils/time.js
+++ b/src/lib/utils/time.js
@@ -1,0 +1,11 @@
+import moment from 'moment'
+
+export function formatUptime(uptime) {
+  const uptimeInMoment = moment.duration(uptime, 'seconds')
+  const days = uptimeInMoment.days()
+  const hours = uptimeInMoment.hours()
+  const daysFormatted = days ? days + 'd' : ''
+  const hoursFormatted = hours ? hours + 'h' : ''
+
+  return [ daysFormatted, hoursFormatted ].filter(Boolean).join(' ')
+}


### PR DESCRIPTION
Examples:
`5d 2h`
`1d`
`23h`

We can change the format to something like:
`5 days, 2 hours`
`1 day`
`23 hours`

But I think it would be better to keep it short?