### PR TITLE
Move prop-types from dev to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "left-pad": "^1.1.3",
     "moment": "^2.18.1",
     "opencollective": "^1.0.3",
+    "prop-types": "^15.5.10",
     "public-ip": "^2.0.1",
     "spotify-node-applescript": "^1.1.0",
     "systeminformation": "^3.4.1"
@@ -50,7 +51,6 @@
     "jest": "^20.0.4",
     "lint-staged": "^4.0.0",
     "prettier": "^1.5.2",
-    "prop-types": "^15.5.10",
     "webpack": "2.2.0-rc.1",
     "webpack-node-externals": "^1.3.3",
     "xo": "^0.18.2",


### PR DESCRIPTION
Fixes #140 - prop-types is used at runtime.