### PR TITLE
Fix horizontal scrollbar appearing on Hyper window

### DIFF
--- a/src/lib/core/hyperline.js
+++ b/src/lib/core/hyperline.js
@@ -23,7 +23,8 @@ class HyperLine extends Component {
         font: 'bold 10px Monospace',
         pointerEvents: 'none',
         background: 'rgba(0, 0, 0, 0.08)',
-        margin: '10px 10px 0 10px'
+        margin: '10px 0',
+        padding: '0 10px',
       },
       wrapper: {
         display: 'flex',


### PR DESCRIPTION
The `overflow: hidden;` property on the Hyperline wrapper element isn't taking `margin` 
into account for the x-axis, so a horizontal scrollbar is shown. 

Here's what this looks like:
![screen shot 2018-03-25 at 2 20 47 pm](https://user-images.githubusercontent.com/2000233/37875628-095bdc42-303a-11e8-9e6c-07506ce8a72d.png)

By using `padding` instead of `margin` on the x-axis , any x-axis overflow is correctly hidden.

Here's how it looks with the changes in this PR:
![screen shot 2018-03-25 at 2 32 35 pm](https://user-images.githubusercontent.com/2000233/37875633-15551ec8-303a-11e8-98cc-9e2754f20fd3.png)


