### PR TITLE
Bring back time, uptime and docker plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import HyperLine from './lib/core/hyperline'
 import { getColorList } from './lib/utils/colors'
-import hyperlinePlugins from './lib/plugins'
+import { allPlugins, defaultPlugins } from './lib/plugins'
 
 export function reduceUI(state, { type, config }) {
   switch (type) {
@@ -50,7 +50,7 @@ function filterPluginsByConfig(plugins) {
     return plugins
   }
 
-  plugins = pluginsByName(plugins)
+  plugins = pluginsByName(allPlugins)
   const filtered = []
 
   userPluginNames.forEach((name) => {
@@ -81,7 +81,7 @@ export function decorateHyperLine(HyperLine) {
     }
 
     render() {
-      const plugins = [...this.props.plugins, ...hyperlinePlugins]
+      const plugins = [...this.props.plugins, ...defaultPlugins]
 
       return <HyperLine {...this.props} plugins={filterPluginsByConfig(plugins)} />
     }

--- a/src/lib/plugins/index.js
+++ b/src/lib/plugins/index.js
@@ -1,12 +1,14 @@
 import hostname from './hostname'
 import ip from './ip'
 import memory from './memory'
-// Import Uptime from './uptime'
+import uptime from './uptime'
 import cpu from './cpu'
 import network from './network'
 import battery from './battery'
-// Import Time from './time'
-// Import Docker from './docker'
+import time from './time'
+import docker from './docker'
 import spotify from './spotify'
+// import gitStatus from './git-status'
 
-export default [hostname, ip, memory, battery, cpu, network, spotify]
+export const defaultPlugins = [hostname, ip, memory, battery, cpu, network, spotify]
+export const allPlugins = [hostname, ip, memory, battery, cpu, network, spotify, time, uptime, docker]

--- a/src/lib/plugins/uptime.js
+++ b/src/lib/plugins/uptime.js
@@ -53,7 +53,7 @@ export default class Uptime extends Component {
     return formatUptime(os.uptime())
   }
 
-  template(css) {
+  render() {
     return (
       <div className='wrapper'>
         <PluginIcon /> {this.state.uptime}


### PR DESCRIPTION
This PR allows users to optionally enable time, uptime, and docker plugins. They are disabled by default (i.e. they won't be displayed unless user explicitly list them in the config file). 