### PR TITLE
Fixed contributor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ To set up the project for development:
 
 ## Contributors
 
-This project exists thanks to all the people who contribute.
-<a href="graphs/contributors"><img src="https://opencollective.com/hyperline/contributors.svg?width=890" /></a>
+Thanks to all the <a href="https://github.com/Hyperline/hyperline/graphs/contributors">people who contribute</a>, this project exists because of you. 
+<a href="https://opencollective.com/hyperline"><img src="https://opencollective.com/hyperline/contributors.svg?width=890" /></a>


### PR DESCRIPTION

Fixes #178 Updated README to add a link to the contributors page on Github, this was previously broken and a part of the open collective picture below it. Swapped out this broken link for the image and changed it to a working one.

Also updated grammatical error on link.