### PR TITLE
fix: overlap styles

### DIFF
--- a/src/lib/core/hyperline.js
+++ b/src/lib/core/hyperline.js
@@ -27,12 +27,12 @@ class HyperLine extends Component {
             align-items: center;
             position: absolute;
             overflow: hidden;
-            bottom: 0;
+            bottom: 30px;
             width: 100%;
             height: 18px;
-            font: bold 10px Monospace;
+            font: bold 12px Monospace;
             pointer-events: none;
-            background: rgba(0, 0, 0, 0.08);
+            background: transparent;
             margin: 2px 0;
             padding: 0 10px;
           },

--- a/src/lib/plugins/index.js
+++ b/src/lib/plugins/index.js
@@ -1,12 +1,12 @@
 import hostname from './hostname'
 import ip from './ip'
 import memory from './memory'
-// Import Uptime from './uptime'
+import Uptime from './uptime'
 import cpu from './cpu'
 import network from './network'
 import battery from './battery'
-// Import Time from './time'
-// Import Docker from './docker'
+import Time from './time'
+import Docker from './docker'
 import spotify from './spotify'
 
-export default [hostname, ip, memory, battery, cpu, network, spotify]
+export default [hostname, ip, memory, battery, cpu, network, spotify, Uptime, Time, Docker]


### PR DESCRIPTION
<!-- Love hyperline? Please consider supporting our collective:
👉  https://opencollective.com/hyperline/donate -->
### Style overlaps

When using the `latest` version of hyper, adding elements on the plugins array, it overlaps with existing content.
![Screenshot 2024-04-23 at 3 43 25 PM](https://github.com/Hyperline/hyperline/assets/114107467/1210982d-4d39-4e13-8857-570c3e07fb0a)

## Solution

### Current behavior
After looking for some time, the easiest way to fix it _(not sure if it's the best option)_ is just to add an additional `30px` to the `bottom` on the style `.line`.

### After making the changes
![Screenshot 2024-04-23 at 3 24 52 PM](https://github.com/Hyperline/hyperline/assets/114107467/20e07bd8-4d3b-4f0e-8009-8b19d38d6dc7)

### enabled options